### PR TITLE
Update default ControlPlane version to 1.2.0

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -37,7 +37,7 @@ func NewCreateCommand() *cobra.Command {
 	if err := createControlPlaneCmd.MarkFlagRequired("name"); err != nil {
 		log.Fatalln(err)
 	}
-	createControlPlaneCmd.Flags().StringVar(&controlPlaneVersion, "version", "1.0.1", "Version of control plane")
+	createControlPlaneCmd.Flags().StringVar(&controlPlaneVersion, "version", "1.2.0", "Version of control plane")
 	createClusterCmd.Flags().StringVar(&clusterName, "name", "", "Name of cluster")
 	createClusterCmd.Flags().StringVar(&controlPlaneName, "controlplane", "", "Name of associated control plane")
 	createClusterCmd.Flags().StringVar(&clusterDefPath, "json", "", "Path to JSON cluster definition")


### PR DESCRIPTION
The default value for ControlPlane creation fails given that version is no longer available.