### PR TITLE
Default to 'default' control plane name, allow specifying config

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -39,12 +39,9 @@ func NewCreateCommand() *cobra.Command {
 	}
 	createControlPlaneCmd.Flags().StringVar(&controlPlaneVersion, "version", "1.2.0", "Version of control plane")
 	createClusterCmd.Flags().StringVar(&clusterName, "name", "", "Name of cluster")
-	createClusterCmd.Flags().StringVar(&controlPlaneName, "controlplane", "", "Name of associated control plane")
+	createClusterCmd.Flags().StringVar(&controlPlaneName, "controlplane", "default", "Name of associated control plane")
 	createClusterCmd.Flags().StringVar(&clusterDefPath, "json", "", "Path to JSON cluster definition")
 	if err := createClusterCmd.MarkFlagRequired("name"); err != nil {
-		log.Fatalln(err)
-	}
-	if err := createClusterCmd.MarkFlagRequired("controlplane"); err != nil {
 		log.Fatalln(err)
 	}
 	if err := createClusterCmd.MarkFlagRequired("json"); err != nil {

--- a/cmd/delete/cluster.go
+++ b/cmd/delete/cluster.go
@@ -35,7 +35,7 @@ func deleteClusterCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&clusterName, "name", "", "The name of the cluster to be deleted")
-	cmd.Flags().StringVar(&controlPlaneName, "controlplane", "", "The name of the associated control plane")
+	cmd.Flags().StringVar(&controlPlaneName, "controlplane", "default", "The name of the associated control plane.")
 	return cmd
 }
 

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -43,17 +43,13 @@ func NewGetCommand() *cobra.Command {
 	getCmd.AddCommand(commands...)
 	imagesCmd.Flags().StringVar(&imageName, "name", "", "Name of image")
 	imagesCmd.Flags().StringVar(&imageId, "id", "", "ID of image")
-	clustersCmd.Flags().StringVar(&controlPlaneName, "controlplane", "", "Name of control plane")
+	clustersCmd.Flags().StringVar(&controlPlaneName, "controlplane", "default", "Name of control plane")
 	clustersCmd.Flags().BoolVar(&allFlag, "all", false, "Return all clusters across all control planes")
 	clustersCmd.Flags().StringVar(&clusterName, "name", "", "Name of cluster")
 	clustersCmd.MarkFlagsMutuallyExclusive("controlplane", "all")
-	kubeconfigCmd.Flags().StringVar(&controlPlaneName, "controlplane", "", "Name of control plane")
+	kubeconfigCmd.Flags().StringVar(&controlPlaneName, "controlplane", "default", "Name of control plane")
 	kubeconfigCmd.Flags().StringVar(&clusterName, "cluster", "", "Name of cluster")
-	err := kubeconfigCmd.MarkFlagRequired("controlplane")
-	if err != nil {
-		log.Fatalln(err)
-	}
-	err = kubeconfigCmd.MarkFlagRequired("cluster")
+	err := kubeconfigCmd.MarkFlagRequired("cluster")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&username, "username", "", "Username")
 	rootCmd.PersistentFlags().StringVar(&password, "password", "", "Password")
 	rootCmd.PersistentFlags().StringVar(&project, "project", "", "Project ID")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Path to configuration file")
 	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "Disable server certificate validation, for use when testing")
 
 	return rootCmd


### PR DESCRIPTION
Small quality of life fixes: Default to a control plane name of 'default' if none is specified, and add a flag to specify a path for the config file.