### PR TITLE
Return details for all Control Planes by default, bump cluster creation timeout

### DIFF
--- a/cmd/create/cluster.go
+++ b/cmd/create/cluster.go
@@ -52,7 +52,7 @@ func createCluster(token string) (err error) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	cluster, err := readClusterDefs(clusterDefPath)

--- a/cmd/get/clusters.go
+++ b/cmd/get/clusters.go
@@ -128,18 +128,18 @@ func printClusters(token string, name string) (err error) {
 				printClusterDetails(c.Name, s)
 			}
 		}
-	} else if controlPlaneName != "" {
+	} else if clusterControlPlaneName != "" {
 		var clusters []generated.KubernetesCluster
 		if name != "" {
-			clusters, err = getClusters(controlPlaneName, name, token)
+			clusters, err = getClusters(clusterControlPlaneName, name, token)
 		} else {
-			clusters, err = getClusters(controlPlaneName, "", token)
+			clusters, err = getClusters(clusterControlPlaneName, "", token)
 		}
 		if err != nil {
 			return err
 		}
 		for _, c := range clusters {
-			printClusterDetails(controlPlaneName, c)
+			printClusterDetails(clusterControlPlaneName, c)
 		}
 	} else {
 		log.Fatal("Error: Either --controlplane or --all must be specified")

--- a/cmd/get/controlplanes.go
+++ b/cmd/get/controlplanes.go
@@ -80,7 +80,10 @@ func printControlPlanes(token string) (err error) {
 		return
 	}
 	for _, i := range cps {
-		if (controlPlaneName != "" && i.Name == controlPlaneName) || (controlPlaneName == "") {
+		if i.Name == controlPlaneName {
+			printControlPlaneDetails(i)
+			break
+		} else {
 			printControlPlaneDetails(i)
 		}
 	}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -7,13 +7,14 @@ import (
 )
 
 var (
-	controlPlaneName   string
-	clusterName        string
-	imageName          string
-	imageId            string
-	allFlag            bool
-	insecure           bool
-	url, u, p, project string
+	controlPlaneName        string
+	clusterControlPlaneName string
+	clusterName             string
+	imageName               string
+	imageId                 string
+	allFlag                 bool
+	insecure                bool
+	url, u, p, project      string
 )
 
 type Images struct {
@@ -43,11 +44,11 @@ func NewGetCommand() *cobra.Command {
 	getCmd.AddCommand(commands...)
 	imagesCmd.Flags().StringVar(&imageName, "name", "", "Name of image")
 	imagesCmd.Flags().StringVar(&imageId, "id", "", "ID of image")
-	clustersCmd.Flags().StringVar(&controlPlaneName, "controlplane", "default", "Name of control plane")
+	clustersCmd.Flags().StringVar(&clusterControlPlaneName, "controlplane", "default", "Name of control plane")
 	clustersCmd.Flags().BoolVar(&allFlag, "all", false, "Return all clusters across all control planes")
 	clustersCmd.Flags().StringVar(&clusterName, "name", "", "Name of cluster")
 	clustersCmd.MarkFlagsMutuallyExclusive("controlplane", "all")
-	kubeconfigCmd.Flags().StringVar(&controlPlaneName, "controlplane", "default", "Name of control plane")
+	kubeconfigCmd.Flags().StringVar(&clusterControlPlaneName, "controlplane", "default", "Name of control plane")
 	kubeconfigCmd.Flags().StringVar(&clusterName, "cluster", "", "Name of cluster")
 	err := kubeconfigCmd.MarkFlagRequired("cluster")
 	if err != nil {

--- a/cmd/get/kubeconfig.go
+++ b/cmd/get/kubeconfig.go
@@ -39,7 +39,7 @@ func getKubeConfig(token string) (kubeconfig string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	resp, err := client.GetApiV1ControlplanesControlPlaneNameClustersClusterNameKubeconfig(ctx, controlPlaneName, clusterName)
+	resp, err := client.GetApiV1ControlplanesControlPlaneNameClustersClusterNameKubeconfig(ctx, clusterControlPlaneName, clusterName)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fix the default behaviour for the 'get controlplanes' command so it returns all controlplanes.  Individual control plane details can still be specified with --name.
    
The semantics around these commands needs rethinking, so this can be considered is a short term fix.

Also increase the timeout for cluster creation since 5 seconds is a little optimistic for some environments.

Fixes #22 