### PR TITLE
Fix error message for 404 when getting cluster details

### DIFF
--- a/cmd/get/clusters.go
+++ b/cmd/get/clusters.go
@@ -84,7 +84,7 @@ func getClusters(controlplane string, clustername string, token string) ([]gener
 	if resp.StatusCode != http.StatusOK {
 		switch resp.StatusCode {
 		case http.StatusNotFound:
-			err = fmt.Errorf("Control plane not found, %v", resp.StatusCode)
+			err = fmt.Errorf("Cluster not found, %v", resp.StatusCode)
 		case http.StatusInternalServerError:
 			err = fmt.Errorf("Server error, %v", resp.StatusCode)
 		default:

--- a/cmd/get/controlplanes.go
+++ b/cmd/get/controlplanes.go
@@ -56,8 +56,13 @@ func getControlPlanes(token string) (controlPlanes []generated.ControlPlane, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("Error retrieving control plane information, %v", resp.StatusCode)
-		return
+		switch resp.StatusCode {
+		case http.StatusInternalServerError:
+			err = fmt.Errorf("Server error, %v", resp.StatusCode)
+		default:
+			err = fmt.Errorf("Error retrieving control plane information, %v", resp.StatusCode)
+		}
+		return nil, err
 	}
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
The error message mentions control planes when actually it should be talking about clusters.

Fixes #22 